### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/animation.php
+++ b/syntax/animation.php
@@ -41,7 +41,7 @@ class syntax_plugin_layeranimation_animation extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
     	
         switch ($state) {
             case DOKU_LEXER_ENTER:
@@ -68,7 +68,7 @@ class syntax_plugin_layeranimation_animation extends DokuWiki_Syntax_Plugin {
 	/**
 	* Create output
 	*/
-    function render($mode, &$renderer, $input) {
+    function render($mode, Doku_Renderer $renderer, $input) {
 		global $conf;
         if($mode == 'xhtml'){
 

--- a/syntax/item.php
+++ b/syntax/item.php
@@ -41,7 +41,7 @@ class syntax_plugin_layeranimation_item extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
     	
         switch ($state) {
             case DOKU_LEXER_ENTER:
@@ -68,7 +68,7 @@ class syntax_plugin_layeranimation_item extends DokuWiki_Syntax_Plugin {
 	/**
 	* Create output
 	*/
-    function render($mode, &$renderer, $input) {
+    function render($mode, Doku_Renderer $renderer, $input) {
 		global $conf;
         if($mode == 'xhtml'){
 

--- a/syntax/layer.php
+++ b/syntax/layer.php
@@ -41,7 +41,7 @@ class syntax_plugin_layeranimation_layer extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
     	
         switch ($state) {
             case DOKU_LEXER_ENTER:
@@ -61,7 +61,7 @@ class syntax_plugin_layeranimation_layer extends DokuWiki_Syntax_Plugin {
 	/**
 	* Create output
 	*/
-    function render($mode, &$renderer, $input) {
+    function render($mode, Doku_Renderer $renderer, $input) {
 		global $conf;
         if($mode == 'xhtml'){
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
